### PR TITLE
添加测试用例

### DIFF
--- a/include/http_server.hpp
+++ b/include/http_server.hpp
@@ -26,6 +26,9 @@ public:
     // 启动HTTP服务器，开始监听端口
     void start_server(unsigned short port);
 
+    // 新增的停止服务器接口
+    void stop_server();
+
 
 private:
     // 处理HTTP请求，解析请求参数，并调用回调函数

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -35,7 +35,7 @@ void HttpServer::handle_request(const std::string& mac_address, const std::strin
 }
 
 std::unordered_map<std::string, std::string> HttpServer::analysis_request(http::request<http::string_body> req) {
-    std::string URL = req.target();
+    std::string URL = std::string(req.target());
     std::unordered_map<std::string, std::string> params;
     int start_index = URL.find('?') + 1;
     int end_index;

--- a/src/http_server.cpp
+++ b/src/http_server.cpp
@@ -92,3 +92,11 @@ void HttpServer::do_accept() {
             do_accept();
         });
 }
+
+// 实现停止服务器的函数
+void HttpServer::stop_server() {
+    // 关闭 acceptor，停止监听新的连接
+    acceptor_.close();
+    // 停止 io_context 的运行，这样后续 ioc.run() 就会退出循环
+    ioc_.stop();
+}

--- a/tests/test_http_server.cpp
+++ b/tests/test_http_server.cpp
@@ -36,9 +36,8 @@ TEST_CASE("Test HttpServer handle_request method") {
     server.start_server(8080);
 
     //创建一个测试用的请求流
-    asio::io_context test_ioc;
-    boost::beast::tcp_stream test_request_stream(test_ioc);
-    asio::ip::tcp::resolver resolver(test_ioc);
+    boost::beast::tcp_stream test_request_stream(ioc);
+    asio::ip::tcp::resolver resolver(ioc);
     asio::ip::basic_resolver_results const results = resolver.resolve("localhost", "8080");
     test_request_stream.connect(results);
 
@@ -49,9 +48,6 @@ TEST_CASE("Test HttpServer handle_request method") {
 
     // 发送请求
     http::write(test_request_stream, test_req);
-
-    // 启动请求流的IO上下文
-    test_ioc.run();
 
     // 启动服务器端IO上下文
     ioc.run();

--- a/tests/test_http_server.cpp
+++ b/tests/test_http_server.cpp
@@ -2,6 +2,13 @@
 #include "http_server.hpp"
 #include <iostream>
 #include <functional>
+#include <boost/asio.hpp>
+#include <boost/beast.hpp>
+
+bool mock_wol_callback(const std::string& mac_address, const std::string& ip_address, unsigned short port);
+
+asio::io_context ioc;
+HttpServer server(ioc, mock_wol_callback);
 
 // 定义一个测试用的 Mock 回调函数
 bool mock_wol_callback(const std::string& mac_address, const std::string& ip_address, unsigned short port) {
@@ -14,9 +21,39 @@ bool mock_wol_callback(const std::string& mac_address, const std::string& ip_add
     CHECK(ip_address == "192.168.1.100");
     CHECK(port == 9);
 
+    server.stop_server();
+
     return true;
 }
 
-TEST_CASE("Test HttpServer with valid WOL callback") {
-    CHECK(true);
-}
+// 测试处理请求的逻辑，验证是否能正确解析请求并调用回调函数
+TEST_CASE("Test HttpServer handle_request method") {
+    std::string mac = "00:11:22:33:44:55";
+    std::string ip = "192.168.1.100";
+    unsigned short port = 9;
+
+    // 启动服务器
+    server.start_server(8080);
+
+    //创建一个测试用的请求流
+    asio::io_context test_ioc;
+    boost::beast::tcp_stream test_request_stream(test_ioc);
+    asio::ip::tcp::resolver resolver(test_ioc);
+    asio::ip::basic_resolver_results const results = resolver.resolve("localhost", "8080");
+    test_request_stream.connect(results);
+
+    // 构造一个简单的 WOL 请求
+    http::request<http::string_body> test_req{http::verb::get, "/wol?mac=" + mac + "&ip=" + ip + "&port=" + std::to_string(port), 11};
+    test_req.set(http::field::host, "localhost");
+    test_req.set(http::field::user_agent, BOOST_BEAST_VERSION_STRING);
+
+    // 发送请求
+    http::write(test_request_stream, test_req);
+
+    // 启动请求流的IO上下文
+    test_ioc.run();
+
+    // 启动服务器端IO上下文
+    ioc.run();
+
+} // TEST_CASE


### PR DESCRIPTION
修改了仅使用一个io的场景

- Q1：为什么每个request和server都需要传入一个ioc？
    
    因为他们都作为一个任务添加到了**事件队列**里，通过ioc.run被实际执行。
    
- Q2：为什么非得ioc.run才能执行？
    
    因为他们本质上就是把一堆任务（比如修改后测试用例里的服务器和客户端）添加到**事件队列**里了，然后这俩都在一个ioc里面run并被执行。
    
- Q3：为什么要用ioc，直接顺序执行不香嘛？
    
    网络编程这种就得ioc，你看看如果让你在测试用例里用顺序执行的方式，运行服务器然后模拟客户端发送一个请求，服务器再处理这一个请求检查正确后结束执行，你要怎么做。不说别的，你如果用python的tcp做一个这样的同步接收多个客户端，都需要开多个线程，因为你tcp服务器要监听并等待（网络io阻塞），这个时候正常都得占用cpu资源。异步这个就是为了解决这个问题，让你阻塞的时候可以去干别的事，你看看新的测试用例，不就是一个ioc又给服务器用，又还能发个请求嘛？